### PR TITLE
Fix what would break this server on Windows and macOS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -537,6 +537,17 @@ The package lives in the `jdk.xml.dom` module, which Equinox exports as a system
 `org.eclipse.e4.ui.css.core` uses it with no `Import-Package` either.
 Adding an optional import here was considered and rejected: an optional import that the target platform cannot resolve turns the package into a compile error rather than a graceful degradation.
 
+**A `Location`'s URL is not a path, and the two obvious ways of making one are both wrong off Linux.**
+`FileLocations` is the only place that turns one into a `java.nio.file.Path`.
+`url.getPath()` yields `/C:/eclipse` on Windows, which the path parser rejects outright, and it leaves `%20` in place wherever the URL was encoded, so an installation under `Program Files` misses on every window system.
+`Path.of(url.toURI())` gets both right and throws on the other half of the problem, which is that Equinox does not always encode what it puts in a Location URL, so a path with a space in it is not a URI at all.
+The helper tries the URI form and decodes the raw one by hand when that fails.
+This was a whole class of bug rather than one: the configuration area, the install location, the workspace a restart is sent to, and the jars a target platform search reads were each written a different way, and three of the four were unusable on Windows.
+
+**This repository is developed and tested on Linux, so anything platform shaped is a guess until somebody runs it elsewhere.**
+The fixes so far were found by reading rather than by failing, which means the review is the record: shell selection and process output encoding in `eclipse_run_command`, the URL-to-path conversions above, CRLF line endings in `eclipse_edit_file`, a Windows drive letter read as a URI scheme in `eclipse_apply_css`, an unquoted flight recording path with a space in it, and the token file's access rights, which POSIX permissions cannot express on Windows and an ACL can.
+Prefer `FileLocations.isWindows()` over a fresh `os.name` test, and `Path.startsWith` over a string prefix, since path comparison is case insensitive on Windows and a text one is not.
+
 ## Verifying UI work
 
 A UI change is not verified by reading the JSON.

--- a/README.md
+++ b/README.md
@@ -1671,6 +1671,10 @@ Give enough surrounding text to be unique rather than a bare identifier.
 Writing goes through the workspace, so the file keeps its charset, the resource tree sees the change at once, and the previous content goes into the local history where *Compare With > Local History* recovers it.
 The answer shows the changed lines with context, so it reports the result rather than promising it.
 
+**Line endings need no attention.**
+A file written with CRLF, which is what a repository checked out on Windows looks like, is matched against an `oldText` given with LF: without that every edit spanning a line break in such a file was refused as if the caller had read a different file.
+The file keeps its own delimiter, so the edit is not what converts it, and the answer carries `lineDelimiter` and `matchedAfterConvertingLineEndings` when that is what happened.
+
 For Java, follow the edit with `eclipse_format`.
 
 ### `eclipse_search_text`

--- a/plugins/com.vogella.eclipse.mcp.core/src/com/vogella/eclipse/mcp/core/FileLocations.java
+++ b/plugins/com.vogella.eclipse.mcp.core/src/com/vogella/eclipse/mcp/core/FileLocations.java
@@ -1,0 +1,116 @@
+package com.vogella.eclipse.mcp.core;
+
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+
+/**
+ * Turns the {@code file:} URLs the framework hands out into filesystem paths.
+ * <p>
+ * Every {@code Location} in Equinox answers with a {@code URL}, and the obvious
+ * ways of getting a path back out of one are both wrong off Linux.
+ * {@code url.getPath()} on Windows yields {@code /C:/eclipse}, which
+ * {@link Path#of(String, String...)} rejects outright, and it leaves {@code %20}
+ * in place wherever the URL was encoded, so an installation under
+ * {@code Program Files} misses on any window system. Going through
+ * {@link Path#of(URI)} is the only form that decodes the escapes and knows about
+ * drive letters and UNC shares.
+ * <p>
+ * That alone is not enough either: Equinox does not always encode what it puts
+ * in a Location URL, so a path with a space in it is not a valid URI and
+ * {@link URI#create(String)} throws. The raw form is therefore decoded by hand
+ * as the fallback, which is what keeps this from failing on exactly the
+ * installations it is meant to describe.
+ */
+public final class FileLocations {
+
+	private static final String FILE_SCHEME = "file:"; //$NON-NLS-1$
+
+	private FileLocations() {
+	}
+
+	/** Whether this JVM runs on a window system with drive letters and backslashes. */
+	public static boolean isWindows() {
+		// the separator rather than os.name: it is what the path parser itself uses,
+		// so it cannot disagree with the thing this class has to get right
+		return java.io.File.separatorChar == '\\';
+	}
+
+	/** The local path a {@code file:} URL names, or {@code null} when it names none. */
+	public static Path pathOf(URL url) {
+		return url == null ? null : pathOf(url.toString());
+	}
+
+	/**
+	 * The local path for a {@code file:} URL or for a plain filesystem path,
+	 * whichever was given.
+	 *
+	 * @return {@code null} when it is neither
+	 */
+	public static Path pathOf(String value) {
+		if (value == null || value.isBlank()) {
+			return null;
+		}
+		String text = value.strip();
+		if (!isFileUrl(text)) {
+			try {
+				return Path.of(text);
+			} catch (InvalidPathException e) {
+				return null;
+			}
+		}
+		try {
+			return Path.of(URI.create(text));
+		} catch (RuntimeException e) {
+			return fromUnencodedUrl(text);
+		}
+	}
+
+	private static boolean isFileUrl(String text) {
+		return text.regionMatches(true, 0, FILE_SCHEME, 0, FILE_SCHEME.length());
+	}
+
+	/**
+	 * The path of a {@code file:} URL that is not a well formed URI, which is what
+	 * an unencoded space produces.
+	 */
+	private static Path fromUnencodedUrl(String url) {
+		String path = decode(url.substring(FILE_SCHEME.length()));
+		if (isWindows()) {
+			path = path.replace('/', '\\');
+			// "/C:/eclipse" is what a URL carries and "C:\eclipse" is what the path
+			// parser accepts; a UNC "\\host\share" keeps both of its leading slashes
+			if (path.length() > 2 && path.charAt(0) == '\\' && path.charAt(2) == ':') {
+				path = path.substring(1);
+			}
+		}
+		try {
+			return Path.of(path);
+		} catch (InvalidPathException e) {
+			return null;
+		}
+	}
+
+	/** Percent decoding only, never the {@code +} of a query string, which a path may contain. */
+	private static String decode(String value) {
+		if (value.indexOf('%') < 0) {
+			return value;
+		}
+		ByteArrayOutputStream bytes = new ByteArrayOutputStream(value.length());
+		for (int i = 0; i < value.length(); i++) {
+			char c = value.charAt(i);
+			int high = i + 2 < value.length() ? Character.digit(value.charAt(i + 1), 16) : -1;
+			int low = i + 2 < value.length() ? Character.digit(value.charAt(i + 2), 16) : -1;
+			if (c == '%' && high >= 0 && low >= 0) {
+				bytes.write(high << 4 | low);
+				i += 2;
+			} else {
+				bytes.writeBytes(String.valueOf(c).getBytes(StandardCharsets.UTF_8));
+			}
+		}
+		return bytes.toString(StandardCharsets.UTF_8);
+	}
+}

--- a/plugins/com.vogella.eclipse.mcp.core/src/com/vogella/eclipse/mcp/core/LaunchRecording.java
+++ b/plugins/com.vogella.eclipse.mcp.core/src/com/vogella/eclipse/mcp/core/LaunchRecording.java
@@ -53,8 +53,13 @@ public final class LaunchRecording {
 	 */
 	public static String vmArgument(String settings, Path file, int seconds) {
 		String duration = seconds > 0 ? ",duration=%ds".formatted(Integer.valueOf(seconds)) : ""; //$NON-NLS-1$ //$NON-NLS-2$
-		return "-XX:StartFlightRecording=name=%s,settings=%s,dumponexit=true%s,filename=%s".formatted(NAME, settings, //$NON-NLS-1$
-				duration, file);
+		String argument = "-XX:StartFlightRecording=name=%s,settings=%s,dumponexit=true%s,filename=%s" //$NON-NLS-1$
+				.formatted(NAME, settings, duration, file);
+		// the launch keeps its VM arguments as one string and the platform splits it
+		// on whitespace, so an unquoted path with a space in it arrives as two
+		// arguments and the launch fails on the second. The temporary directory has
+		// one on any Windows account whose name has one, which is most of them
+		return argument.indexOf(' ') < 0 ? argument : '"' + argument + '"'; //$NON-NLS-1$
 	}
 
 	/** Appended rather than replaced, so a caller's own VM arguments survive. */

--- a/plugins/com.vogella.eclipse.mcp.core/src/com/vogella/eclipse/mcp/core/internal/CommandRegistry.java
+++ b/plugins/com.vogella.eclipse.mcp.core/src/com/vogella/eclipse/mcp/core/internal/CommandRegistry.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
@@ -182,8 +183,7 @@ public final class CommandRegistry {
 				Process process = builder.start();
 				execution.process = process;
 				try (InputStream stream = process.getInputStream();
-						BufferedReader reader = new BufferedReader(
-								new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+						BufferedReader reader = new BufferedReader(new InputStreamReader(stream, outputCharset()))) {
 					String line;
 					while ((line = reader.readLine()) != null) {
 						execution.append(line);
@@ -204,6 +204,29 @@ public final class CommandRegistry {
 		job.setPriority(Job.LONG);
 		job.schedule();
 		return execution;
+	}
+
+	/**
+	 * What a spawned process writes its output in.
+	 * <p>
+	 * Not UTF-8 unconditionally: since JDK 18 the JVM's own default is UTF-8
+	 * everywhere, but a Windows console and the tools that write to it still use
+	 * the machine's ANSI or OEM code page, so decoding a Maven log as UTF-8 there
+	 * turns every non-ASCII byte into a replacement character. {@code native.encoding}
+	 * is the JVM's report of what the operating system actually uses, and it is
+	 * UTF-8 on the Linux and macOS installations this changes nothing for.
+	 */
+	static Charset outputCharset() {
+		String name = System.getProperty("native.encoding"); //$NON-NLS-1$
+		if (name == null || name.isBlank()) {
+			return StandardCharsets.UTF_8;
+		}
+		try {
+			return Charset.forName(name.strip());
+		} catch (IllegalArgumentException e) {
+			// an encoding this JVM does not know is no reason to lose the output
+			return StandardCharsets.UTF_8;
+		}
 	}
 
 	/** Only for tests. */

--- a/plugins/com.vogella.eclipse.mcp.core/src/com/vogella/eclipse/mcp/core/internal/EditFileTool.java
+++ b/plugins/com.vogella.eclipse.mcp.core/src/com/vogella/eclipse/mcp/core/internal/EditFileTool.java
@@ -37,7 +37,7 @@ public final class EditFileTool implements IMcpTool {
 
 	@Override
 	public String getDescription() {
-		return "Replaces one passage of a workspace file with another. MODIFIES THE WORKSPACE. This is how a file is changed without resending it: eclipse_write_file takes the complete content, so changing one line of an 800 line file through it means reading and returning all 800. THE EDIT IS CHECKED AGAINST WHAT YOU BELIEVE IS THERE: oldText that matches nothing is refused, and oldText that matches more than once is refused with the count unless replaceAll is set, so an edit made on a stale reading of the file fails instead of landing somewhere unintended. Give enough surrounding text to be unique rather than a bare identifier. Writing goes through the workspace, so the file keeps its charset, the resource tree sees the change at once, and the previous content goes into the local history where Compare With > Local History recovers it. The answer shows the changed lines with context. Use eclipse_format afterwards for Java."; //$NON-NLS-1$
+		return "Replaces one passage of a workspace file with another. MODIFIES THE WORKSPACE. This is how a file is changed without resending it: eclipse_write_file takes the complete content, so changing one line of an 800 line file through it means reading and returning all 800. THE EDIT IS CHECKED AGAINST WHAT YOU BELIEVE IS THERE: oldText that matches nothing is refused, and oldText that matches more than once is refused with the count unless replaceAll is set, so an edit made on a stale reading of the file fails instead of landing somewhere unintended. Line endings need no attention: a file written with CRLF is matched against text given with LF, and the answer reports lineDelimiter when that is what happened. Give enough surrounding text to be unique rather than a bare identifier. Writing goes through the workspace, so the file keeps its charset, the resource tree sees the change at once, and the previous content goes into the local history where Compare With > Local History recovers it. The answer shows the changed lines with context. Use eclipse_format afterwards for Java."; //$NON-NLS-1$
 	}
 
 	@Override
@@ -105,7 +105,14 @@ public final class EditFileTool implements IMcpTool {
 			return McpToolResult.error("Could not read '%s': %s".formatted(path, e)); //$NON-NLS-1$
 		}
 
-		int matches = count(content, oldText);
+		// a file checked out on Windows has CRLF line endings while a client composing
+		// an edit sends LF, so a passage spanning a line break matches nothing at all
+		// and the refusal reads as a stale reading of the file rather than as what it
+		// is. The delimiter belongs to the file, so the caller's text is brought to it
+		boolean crlf = count(content, oldText) == 0 && oldText.indexOf('\n') >= 0 && usesCrlf(content);
+		String wanted = crlf ? toCrlf(oldText) : oldText;
+		String replacement = crlf ? toCrlf(newText) : newText;
+		int matches = count(content, wanted);
 		JsonObject result = new JsonObject().put("path", file.getFullPath().toString()) //$NON-NLS-1$
 				.put("matches", Integer.valueOf(matches)); //$NON-NLS-1$
 		if (matches == 0) {
@@ -113,17 +120,21 @@ public final class EditFileTool implements IMcpTool {
 					"'oldText' does not occur in %s, so nothing was changed. The file may have moved on since you read it, or the passage may differ in whitespace or line endings." //$NON-NLS-1$
 							.formatted(path));
 		}
+		if (crlf) {
+			result.put("lineDelimiter", "\\r\\n") //$NON-NLS-1$ //$NON-NLS-2$
+					.put("matchedAfterConvertingLineEndings", Boolean.TRUE); //$NON-NLS-1$
+		}
 		if (matches > 1 && !replaceAll) {
 			return McpToolResult.error(
 					"'oldText' occurs %d times in %s, so which one was meant is not decidable. Give more surrounding text, or pass replaceAll true to change all of them." //$NON-NLS-1$
 							.formatted(Integer.valueOf(matches), path));
 		}
 
-		String edited = replaceAll ? content.replace(oldText, newText)
-				: replaceFirst(content, oldText, newText);
-		int line = lineOf(content, content.indexOf(oldText));
+		String edited = replaceAll ? content.replace(wanted, replacement)
+				: replaceFirst(content, wanted, replacement);
+		int line = lineOf(content, content.indexOf(wanted));
 		result.put("replacements", Integer.valueOf(replaceAll ? matches : 1)) //$NON-NLS-1$
-				.put("changedLines", changedLines(content, oldText)) //$NON-NLS-1$
+				.put("changedLines", changedLines(content, wanted)) //$NON-NLS-1$
 				.put("firstChangedLine", Integer.valueOf(line)) //$NON-NLS-1$
 				.put("charset", charset.name()) //$NON-NLS-1$
 				.put("context", context(edited, line)); //$NON-NLS-1$
@@ -159,6 +170,21 @@ public final class EditFileTool implements IMcpTool {
 		return "The previous content is in the local history. Auto-build is OFF in this workspace, so nothing has compiled the change yet: run eclipse_build before believing any problem report. eclipse_format tidies Java."; //$NON-NLS-1$
 	}
 
+	/**
+	 * Whether the file is written with CRLF, decided on the first line break: a file
+	 * with mixed endings is one an editor has already half converted, and its next
+	 * line break is the one this edit has to land beside.
+	 */
+	private static boolean usesCrlf(String content) {
+		int at = content.indexOf('\n');
+		return at > 0 && content.charAt(at - 1) == '\r';
+	}
+
+	/** The text with every bare LF turned into CRLF, leaving CRLF that is already there. */
+	private static String toCrlf(String text) {
+		return text.replace("\r\n", "\n").replace("\n", "\r\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+	}
+
 	static int count(String content, String text) {
 		int found = 0;
 		for (int at = content.indexOf(text); at >= 0; at = content.indexOf(text, at + text.length())) {
@@ -183,9 +209,13 @@ public final class EditFileTool implements IMcpTool {
 		return line;
 	}
 
-	/** The edited file around the change, so the answer shows the result rather than promising it. */
+	/**
+	 * The edited file around the change, so the answer shows the result rather than
+	 * promising it. Split on LF and stripped of the CR a CRLF file leaves behind,
+	 * which would otherwise reach the caller as a stray carriage return per line.
+	 */
 	static String context(String content, int line) {
-		String[] lines = content.split("\n", -1); //$NON-NLS-1$
+		String[] lines = content.split("\r?\n", -1); //$NON-NLS-1$
 		int from = Math.max(0, line - 1 - CONTEXT_LINES);
 		int to = Math.min(lines.length, line + CONTEXT_LINES);
 		StringBuilder text = new StringBuilder();

--- a/plugins/com.vogella.eclipse.mcp.core/src/com/vogella/eclipse/mcp/core/internal/InstallBundleTool.java
+++ b/plugins/com.vogella.eclipse.mcp.core/src/com/vogella/eclipse/mcp/core/internal/InstallBundleTool.java
@@ -2,7 +2,6 @@ package com.vogella.eclipse.mcp.core.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -43,6 +42,7 @@ import org.osgi.framework.wiring.BundleWiring;
 import org.osgi.framework.wiring.FrameworkWiring;
 
 import com.vogella.eclipse.mcp.core.CallBudget;
+import com.vogella.eclipse.mcp.core.FileLocations;
 import com.vogella.eclipse.mcp.core.IMcpTool;
 import com.vogella.eclipse.mcp.core.McpToolResult;
 import com.vogella.eclipse.mcp.core.ToolArguments;
@@ -288,12 +288,10 @@ public final class InstallBundleTool implements IMcpTool {
 		if (installLocation == null || installLocation.getURL() == null) {
 			return McpToolResult.error("This IDE has no readable installation location, so there is no dropins directory to copy into."); //$NON-NLS-1$
 		}
-		Path installation;
-		try {
-			installation = Path.of(installLocation.getURL().toURI());
-		} catch (Exception e) {
-			return McpToolResult.error("The installation location %s is not a local directory: %s" //$NON-NLS-1$
-					.formatted(installLocation.getURL(), rootMessage(e)));
+		Path installation = FileLocations.pathOf(installLocation.getURL());
+		if (installation == null) {
+			return McpToolResult.error(
+					"The installation location %s is not a local directory.".formatted(installLocation.getURL())); //$NON-NLS-1$
 		}
 		Path dropins = installation.resolve("dropins"); //$NON-NLS-1$
 		Path target = dropins.resolve(jar.getFileName());
@@ -601,12 +599,8 @@ public final class InstallBundleTool implements IMcpTool {
 		if (!path.startsWith("file:")) { //$NON-NLS-1$
 			return null;
 		}
-		try {
-			Path candidate = Path.of(URI.create(path));
-			return Files.isRegularFile(candidate) ? candidate : null;
-		} catch (RuntimeException e) {
-			return null;
-		}
+		Path candidate = FileLocations.pathOf(path);
+		return candidate != null && Files.isRegularFile(candidate) ? candidate : null;
 	}
 
 	private static String sha256(Path file) throws IOException {

--- a/plugins/com.vogella.eclipse.mcp.core/src/com/vogella/eclipse/mcp/core/internal/RunCommandTool.java
+++ b/plugins/com.vogella.eclipse.mcp.core/src/com/vogella/eclipse/mcp/core/internal/RunCommandTool.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 import com.vogella.eclipse.mcp.core.CallBudget;
+import com.vogella.eclipse.mcp.core.FileLocations;
 import com.vogella.eclipse.mcp.core.IMcpTool;
 import com.vogella.eclipse.mcp.core.McpToolException;
 import com.vogella.eclipse.mcp.core.McpToolResult;
@@ -97,8 +98,7 @@ public final class RunCommandTool implements IMcpTool {
 		}
 		// through a shell, because the point of the string form is that a caller can
 		// write the command line it would type
-		return System.getProperty("os.name", "").toLowerCase().contains("win") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-				? List.of("cmd.exe", "/c", line) //$NON-NLS-1$ //$NON-NLS-2$
+		return FileLocations.isWindows() ? List.of("cmd.exe", "/c", line) //$NON-NLS-1$ //$NON-NLS-2$
 				: List.of("/bin/sh", "-c", line); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 

--- a/plugins/com.vogella.eclipse.mcp.core/src/com/vogella/eclipse/mcp/core/internal/SubstituteBundleTool.java
+++ b/plugins/com.vogella.eclipse.mcp.core/src/com/vogella/eclipse/mcp/core/internal/SubstituteBundleTool.java
@@ -2,8 +2,6 @@ package com.vogella.eclipse.mcp.core.internal;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
@@ -25,6 +23,7 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 
+import com.vogella.eclipse.mcp.core.FileLocations;
 import com.vogella.eclipse.mcp.core.IMcpTool;
 import com.vogella.eclipse.mcp.core.McpToolResult;
 import com.vogella.eclipse.mcp.core.ToolArguments;
@@ -199,7 +198,7 @@ public final class SubstituteBundleTool implements IMcpTool {
 		String path = fields[2];
 		try {
 			if (path.startsWith("file:")) { //$NON-NLS-1$
-				return Path.of(URI.create(path));
+				return FileLocations.pathOf(path);
 			}
 			Path installation = configuration.getParent();
 			return installation == null ? null : installation.resolve(path);
@@ -776,10 +775,6 @@ public final class SubstituteBundleTool implements IMcpTool {
 		if (location == null || location.getURL() == null) {
 			return null;
 		}
-		try {
-			return Path.of(location.getURL().toURI());
-		} catch (URISyntaxException | RuntimeException e) {
-			return null;
-		}
+		return FileLocations.pathOf(location.getURL());
 	}
 }

--- a/plugins/com.vogella.eclipse.mcp.git/src/com/vogella/eclipse/mcp/git/internal/AddGitRepositoryTool.java
+++ b/plugins/com.vogella.eclipse.mcp.git/src/com/vogella/eclipse/mcp/git/internal/AddGitRepositoryTool.java
@@ -1,6 +1,7 @@
 package com.vogella.eclipse.mcp.git.internal;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -133,13 +134,19 @@ public final class AddGitRepositoryTool implements IMcpTool {
 		if (workTree == null) {
 			return List.of();
 		}
-		String root = workTree.getAbsolutePath() + File.separator;
+		// through Path rather than a string prefix: comparing absolute paths as text
+		// is case sensitive, and on Windows the same directory reaches this with the
+		// casing whoever produced it happened to use, so a working tree naming the
+		// profile directory in one casing would not contain a project naming it in
+		// another. Path comparison is case insensitive where the filesystem is
+		Path root = workTree.toPath().toAbsolutePath().normalize();
 		List<IProject> inside = new ArrayList<>();
 		for (IProject project : ResourcesPlugin.getWorkspace().getRoot().getProjects()) {
 			if (!project.isAccessible() || project.getLocation() == null) {
 				continue;
 			}
-			if (project.getLocation().toFile().getAbsolutePath().startsWith(root)) {
+			Path location = project.getLocation().toFile().toPath().toAbsolutePath().normalize();
+			if (!location.equals(root) && location.startsWith(root)) {
 				inside.add(project);
 			}
 		}

--- a/plugins/com.vogella.eclipse.mcp.jdt/src/com/vogella/eclipse/mcp/jdt/internal/TestRunRegistry.java
+++ b/plugins/com.vogella.eclipse.mcp.jdt/src/com/vogella/eclipse/mcp/jdt/internal/TestRunRegistry.java
@@ -1,6 +1,9 @@
 package com.vogella.eclipse.mcp.jdt.internal;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -261,6 +264,23 @@ public final class TestRunRegistry {
 	/** Errors reported from a launched platform's log. Enough to diagnose, not a dump. */
 	private static final int MAX_LAUNCH_ERRORS = 8;
 
+	/**
+	 * The lines of a platform log.
+	 * <p>
+	 * Read leniently rather than through {@code Files.readAllLines}, which decodes
+	 * as UTF-8 and throws on the first byte that is not: the log carries whatever
+	 * encoding the launched platform's default was, which on Windows is a code page
+	 * and not UTF-8, and one stack trace with an accented class name would
+	 * otherwise cost the whole diagnosis. Split on either delimiter for the same
+	 * reason.
+	 */
+	private static List<String> logLines(Path log) throws IOException {
+		var decoder = StandardCharsets.UTF_8.newDecoder().onMalformedInput(CodingErrorAction.REPLACE)
+				.onUnmappableCharacter(CodingErrorAction.REPLACE);
+		String text = decoder.decode(ByteBuffer.wrap(Files.readAllBytes(log))).toString();
+		return List.of(text.split("\r\n|\n|\r", -1)); //$NON-NLS-1$
+	}
+
 	/** Error entries from the log of the platform that was launched, newest last. */
 	private static JsonArray launchedPlatformErrors(Run run) {
 		JsonArray errors = new JsonArray();
@@ -285,7 +305,7 @@ public final class TestRunRegistry {
 			}
 			List<String> collected = new ArrayList<>();
 			String entry = null;
-			for (String line : Files.readAllLines(log)) {
+			for (String line : logLines(log)) {
 				if (line.startsWith("!ENTRY") && line.contains(" 4 ")) { //$NON-NLS-1$ //$NON-NLS-2$
 					entry = line.substring("!ENTRY ".length()); //$NON-NLS-1$
 				} else if (entry != null && line.startsWith("!MESSAGE")) { //$NON-NLS-1$

--- a/plugins/com.vogella.eclipse.mcp.pde/src/com/vogella/eclipse/mcp/pde/internal/FindResourcesTool.java
+++ b/plugins/com.vogella.eclipse.mcp.pde/src/com/vogella/eclipse/mcp/pde/internal/FindResourcesTool.java
@@ -32,6 +32,7 @@ import org.eclipse.pde.core.target.TargetBundle;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
+import com.vogella.eclipse.mcp.core.FileLocations;
 import com.vogella.eclipse.mcp.core.Globs;
 import com.vogella.eclipse.mcp.core.IMcpTool;
 import com.vogella.eclipse.mcp.core.McpToolResult;
@@ -234,10 +235,10 @@ public final class FindResourcesTool implements IMcpTool {
 							&& (symbolicName == null || !symbolicName.contains(search.bundleFilter)))) {
 						continue;
 					}
-					File file = new File(URI.create(location).getPath());
-					if (!file.isFile()) {
-						file = new File(location);
-					}
+					// getLocation is a file: URL, and reading its path directly hands
+					// back "/C:/..." on Windows and leaves %20 in an encoded one
+					Path resolved = FileLocations.pathOf(location);
+					File file = resolved == null ? new File(location) : resolved.toFile();
 					if (file.isFile()) {
 						searchJar(file, symbolicName, version, search);
 					}

--- a/plugins/com.vogella.eclipse.mcp.pde/src/com/vogella/eclipse/mcp/pde/internal/TargetPlatforms.java
+++ b/plugins/com.vogella.eclipse.mcp.pde/src/com/vogella/eclipse/mcp/pde/internal/TargetPlatforms.java
@@ -1,6 +1,7 @@
 package com.vogella.eclipse.mcp.pde.internal;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
@@ -19,6 +20,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
 
+import com.vogella.eclipse.mcp.core.FileLocations;
 import com.vogella.eclipse.mcp.core.JreUsability;
 import com.vogella.eclipse.mcp.core.McpToolResult;
 import com.vogella.eclipse.mcp.core.json.JsonArray;
@@ -224,15 +226,24 @@ final class TargetPlatforms {
 			if (path == null) {
 				return null;
 			}
-			String temporary = System.getProperty("java.io.tmpdir", "/tmp"); //$NON-NLS-1$ //$NON-NLS-2$
-			return trailing(path).equals(trailing(temporary)) ? null : path;
+			return isTemporaryDirectory(path) ? null : path;
 		} catch (CoreException | RuntimeException e) {
 			return null;
 		}
 	}
 
-	private static String trailing(String path) {
-		return path.endsWith("/") ? path.substring(0, path.length() - 1) : path; //$NON-NLS-1$
+	/**
+	 * Compared as paths rather than as strings: java.io.tmpdir ends with a
+	 * separator on Windows and not on Linux, the separator itself differs, and
+	 * Windows paths differing only in case are one directory. A string comparison
+	 * therefore said "not the temp directory" off Linux and let PDE's placeholder
+	 * through as if it were a real location.
+	 */
+	private static boolean isTemporaryDirectory(String path) {
+		Path candidate = FileLocations.pathOf(path);
+		Path temporary = FileLocations.pathOf(System.getProperty("java.io.tmpdir")); //$NON-NLS-1$
+		return candidate != null && temporary != null
+				&& candidate.toAbsolutePath().normalize().equals(temporary.toAbsolutePath().normalize());
 	}
 
 	/** The location's own XML, which carries what the API does not expose. */

--- a/plugins/com.vogella.eclipse.mcp.server/src/com/vogella/eclipse/mcp/server/internal/PrivateFiles.java
+++ b/plugins/com.vogella.eclipse.mcp.server/src/com/vogella/eclipse/mcp/server/internal/PrivateFiles.java
@@ -2,15 +2,23 @@ package com.vogella.eclipse.mcp.server.internal;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.AclFileAttributeView;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.attribute.UserPrincipal;
+import java.util.EnumSet;
+import java.util.List;
+
+import org.eclipse.core.runtime.ILog;
 
 /**
- * Writes the files that carry the bearer token, readable by their owner only where the
- * platform supports it.
+ * Writes the files that carry the bearer token, readable by their owner only.
  */
 final class PrivateFiles {
 
@@ -38,14 +46,45 @@ final class PrivateFiles {
 			Files.createFile(temporary,
 					PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString(OWNER_ONLY)));
 		} catch (UnsupportedOperationException e) {
-			// no POSIX permissions on this platform, the file inherits the directory's access rights
+			// no POSIX permissions here, which is Windows, where the access rights are
+			// an ACL and the file is created before one can be put on it
 			Files.createFile(temporary);
+			restrictToOwner(temporary);
 		}
 		Files.writeString(temporary, content, StandardCharsets.UTF_8);
 		try {
 			Files.move(temporary, path, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
 		} catch (AtomicMoveNotSupportedException e) {
 			Files.move(temporary, path, StandardCopyOption.REPLACE_EXISTING);
+		}
+	}
+
+	/**
+	 * Replaces a file's ACL with one entry granting its owner everything, which is
+	 * what {@code rw-------} means on a filesystem that has no POSIX permissions.
+	 * <p>
+	 * Without this the token file inherits the directory's rights on Windows. That
+	 * is usually the user profile and usually narrow enough, but "usually" is not a
+	 * property to give a secret, and the failure is silent: a world readable token
+	 * looks exactly like a private one. The ACL travels with the file through the
+	 * atomic move, so it is set on the temporary file rather than afterwards.
+	 * <p>
+	 * A filesystem without ACLs either is not reached here, since it would have had
+	 * POSIX permissions, or cannot express the restriction at all, and a token the
+	 * server cannot write is worse than one whose file it could not narrow.
+	 */
+	private static void restrictToOwner(Path path) {
+		AclFileAttributeView acl = Files.getFileAttributeView(path, AclFileAttributeView.class);
+		if (acl == null) {
+			return;
+		}
+		try {
+			UserPrincipal owner = acl.getOwner();
+			acl.setAcl(List.of(AclEntry.newBuilder().setType(AclEntryType.ALLOW).setPrincipal(owner)
+					.setPermissions(EnumSet.allOf(AclEntryPermission.class)).build()));
+		} catch (IOException | RuntimeException e) {
+			ILog.get().warn("Could not restrict %s to its owner, so it keeps the access rights of its directory" //$NON-NLS-1$
+					.formatted(path), e);
 		}
 	}
 }

--- a/plugins/com.vogella.eclipse.mcp.ui/src/com/vogella/eclipse/mcp/ui/internal/RestartTool.java
+++ b/plugins/com.vogella.eclipse.mcp.ui/src/com/vogella/eclipse/mcp/ui/internal/RestartTool.java
@@ -1,7 +1,6 @@
 package com.vogella.eclipse.mcp.ui.internal;
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -25,6 +24,7 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 
+import com.vogella.eclipse.mcp.core.FileLocations;
 import com.vogella.eclipse.mcp.core.IMcpTool;
 import com.vogella.eclipse.mcp.core.LaunchAttributes;
 import com.vogella.eclipse.mcp.core.McpToolResult;
@@ -348,14 +348,10 @@ public final class RestartTool implements IMcpTool {
 	 * that hands back what it was given would otherwise be refused.
 	 */
 	public static Path pathOf(String workspace) {
-		try {
-			if (workspace.startsWith("file:")) { //$NON-NLS-1$
-				return Path.of(URI.create(workspace).getPath());
-			}
-			return Path.of(workspace);
-		} catch (RuntimeException e) {
-			return null;
-		}
+		// through FileLocations rather than URI.getPath(): that form hands back
+		// "/C:/ws" for a Windows workspace, which is not a path at all, and leaves
+		// %20 wherever the URL was encoded
+		return FileLocations.pathOf(workspace);
 	}
 
 	/**

--- a/plugins/com.vogella.eclipse.mcp.ui/src/com/vogella/eclipse/mcp/ui/internal/SplashBranding.java
+++ b/plugins/com.vogella.eclipse.mcp.ui/src/com/vogella/eclipse/mcp/ui/internal/SplashBranding.java
@@ -19,6 +19,7 @@ import org.osgi.framework.FrameworkUtil;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
+import com.vogella.eclipse.mcp.core.FileLocations;
 import com.vogella.eclipse.mcp.server.McpPreferences;
 
 /**
@@ -129,9 +130,9 @@ final class SplashBranding {
 
 	private static Path configurationArea() {
 		Location location = Platform.getConfigurationLocation();
-		URL url = location == null ? null : location.getURL();
-		return url == null ? Path.of(System.getProperty("user.home"), ".eclipse") //$NON-NLS-1$ //$NON-NLS-2$
-				: Path.of(url.getPath());
+		Path area = location == null ? null : FileLocations.pathOf(location.getURL());
+		return area == null ? Path.of(System.getProperty("user.home"), ".eclipse") //$NON-NLS-1$ //$NON-NLS-2$
+				: area;
 	}
 
 	private static Path configFile() {

--- a/plugins/com.vogella.eclipse.mcp.ui/src/com/vogella/eclipse/mcp/ui/internal/ThemeTools.java
+++ b/plugins/com.vogella.eclipse.mcp.ui/src/com/vogella/eclipse/mcp/ui/internal/ThemeTools.java
@@ -152,9 +152,14 @@ public final class ThemeTools {
 			return UiThread.call(UI_TIMEOUT_SECONDS, () -> CssStyling.registerTheme(id, label, stylesheetUri));
 		}
 
-		/** Turns a bare path into an absolute file URI; a URI with a scheme passes through. */
+		/**
+		 * Turns a bare path into an absolute file URI; a URI with a scheme passes
+		 * through. The scheme is two characters at least, because a one letter one is
+		 * a Windows drive: {@code C:\themes\dark.css} otherwise reads as a URI and
+		 * is handed to the CSS engine unchanged, which finds nothing there.
+		 */
 		private static String stylesheetUri(String css) {
-			if (!css.matches("(?i)[a-z][a-z0-9+.-]*:.*")) { //$NON-NLS-1$
+			if (!css.matches("(?i)[a-z][a-z0-9+.-]+:.*")) { //$NON-NLS-1$
 				Path path = Path.of(css);
 				if (!Files.exists(path)) {
 					return null;

--- a/tests/com.vogella.eclipse.mcp.core.tests/src/com/vogella/eclipse/mcp/core/tests/EditFileToolTest.java
+++ b/tests/com.vogella.eclipse.mcp.core.tests/src/com/vogella/eclipse/mcp/core/tests/EditFileToolTest.java
@@ -50,6 +50,25 @@ class EditFileToolTest {
 	}
 
 	@Test
+	void matchesACrlfFileAgainstTextGivenWithLf() throws Exception {
+		// what a repository checked out on Windows looks like. A client composes its
+		// oldText with LF, so without this every multi-line edit of such a file is
+		// refused as if the caller had read a different file
+		IFile file = write("Crlf.java", "class Crlf {\r\n\tint width = 1;\r\n\tint height = 2;\r\n}\r\n");
+
+		Map<String, Object> result = TestFixture.callAndParse(TOOL, Map.of("path", file.getFullPath().toString(),
+				"oldText", "\tint width = 1;\n\tint height = 2;", "newText", "\tint width = 3;\n\tint height = 4;"));
+
+		assertEquals(Boolean.TRUE, result.get("edited"), "got " + result);
+		assertEquals(Boolean.TRUE, result.get("matchedAfterConvertingLineEndings"), "got " + result);
+		// the file keeps its own delimiter: the edit is not what converts it
+		assertEquals("class Crlf {\r\n\tint width = 3;\r\n\tint height = 4;\r\n}\r\n", read(file));
+		assertTrue(String.valueOf(result.get("context")).contains("int width = 3;"), "got " + result);
+		assertTrue(String.valueOf(result.get("context")).indexOf('\r') < 0,
+				"the context must not carry the file's carriage returns: " + result);
+	}
+
+	@Test
 	void refusesWhenTheExpectedTextIsNotThere() throws Exception {
 		IFile file = write("Sample.java", "class Sample {\n}\n");
 

--- a/tests/com.vogella.eclipse.mcp.core.tests/src/com/vogella/eclipse/mcp/core/tests/FileLocationsTest.java
+++ b/tests/com.vogella.eclipse.mcp.core.tests/src/com/vogella/eclipse/mcp/core/tests/FileLocationsTest.java
@@ -1,0 +1,59 @@
+package com.vogella.eclipse.mcp.core.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import com.vogella.eclipse.mcp.core.FileLocations;
+
+/**
+ * The conversion every {@code Location} in the framework needs, and the two
+ * shapes that used to break it off Linux: a Windows drive letter and a path with
+ * a space in it.
+ */
+class FileLocationsTest {
+
+	@Test
+	void aFileUrlRoundTripsOnEveryWindowSystem() throws Exception {
+		Path directory = Path.of(System.getProperty("java.io.tmpdir")).toAbsolutePath().resolve("mcp-locations");
+
+		assertEquals(directory, FileLocations.pathOf(directory.toUri().toString()));
+		assertEquals(directory, FileLocations.pathOf(directory.toUri().toURL().toString()));
+	}
+
+	@Test
+	void aPlainPathIsTakenAsItIs() {
+		Path directory = Path.of(System.getProperty("java.io.tmpdir")).toAbsolutePath();
+
+		assertEquals(directory, FileLocations.pathOf(directory.toString()));
+	}
+
+	@Test
+	void anEncodedSpaceIsDecoded() {
+		// an installation under "Program Files" is the ordinary case of this, and
+		// url.getPath() used to hand the %20 straight through into a path
+		Path directory = Path.of(System.getProperty("java.io.tmpdir")).toAbsolutePath().resolve("with space");
+
+		assertEquals(directory, FileLocations.pathOf(directory.toUri().toString()));
+	}
+
+	@Test
+	void anUnencodedSpaceIsStillAPath() {
+		// Equinox does not always encode what it puts in a Location URL, and then the
+		// value is not a URI at all, so URI.create throws rather than answering
+		Path directory = Path.of(System.getProperty("java.io.tmpdir")).toAbsolutePath().resolve("with space");
+		String raw = "file:" + directory.toString().replace(java.io.File.separatorChar, '/');
+
+		assertEquals(directory, FileLocations.pathOf(FileLocations.isWindows() ? "file:/" + raw.substring(5) : raw));
+	}
+
+	@Test
+	void nothingIsNothing() {
+		assertNull(FileLocations.pathOf((String) null));
+		assertNull(FileLocations.pathOf("  "));
+		assertNull(FileLocations.pathOf((java.net.URL) null));
+	}
+}

--- a/tests/com.vogella.eclipse.mcp.core.tests/src/com/vogella/eclipse/mcp/core/tests/RestartToolTest.java
+++ b/tests/com.vogella.eclipse.mcp.core.tests/src/com/vogella/eclipse/mcp/core/tests/RestartToolTest.java
@@ -126,9 +126,13 @@ class RestartToolTest {
 
 	@Test
 	void aFileUriIsAcceptedBecauseThatIsWhatTheToolUsedToReport() {
-		// a caller handing back the workspace it was given would otherwise be refused
-		assertEquals(Path.of("/tmp/ws"), RestartTool.pathOf("file:/tmp/ws"));
-		assertEquals(Path.of("/tmp/ws"), RestartTool.pathOf("/tmp/ws"));
+		// a caller handing back the workspace it was given would otherwise be refused.
+		// Built from a real path rather than written out, because "file:/tmp/ws" is
+		// not a path on Windows and this has to hold on every window system
+		Path workspace = Path.of(System.getProperty("java.io.tmpdir")).toAbsolutePath().resolve("ws");
+
+		assertEquals(workspace, RestartTool.pathOf(workspace.toUri().toString()));
+		assertEquals(workspace, RestartTool.pathOf(workspace.toString()));
 	}
 
 	@Test

--- a/tests/com.vogella.eclipse.mcp.core.tests/src/com/vogella/eclipse/mcp/core/tests/RunCommandToolTest.java
+++ b/tests/com.vogella.eclipse.mcp.core.tests/src/com/vogella/eclipse/mcp/core/tests/RunCommandToolTest.java
@@ -18,13 +18,16 @@ import com.vogella.eclipse.mcp.core.McpToolResult;
  */
 class RunCommandToolTest {
 
+	/** Windows has no echo.exe and no /bin/sh, so the shell form is the portable one. */
+	private static final boolean WINDOWS = java.io.File.separatorChar == '\\';
+
 	@Test
 	@SuppressWarnings("unchecked")
 	void runsACommandAndCapturesItsOutput() throws Exception {
 		Path directory = Files.createTempDirectory("mcp-command-run");
 
 		Map<String, Object> result = TestFixture.callAndParse("eclipse_run_command",
-				Map.of("args", List.of("echo", "from the command"), "directory", directory.toString(),
+				Map.of("command", "echo from the command", "directory", directory.toString(),
 						"wait", Boolean.TRUE, "timeoutSeconds", Integer.valueOf(20)));
 
 		assertEquals("done", result.get("state"), "got " + result);
@@ -41,8 +44,11 @@ class RunCommandToolTest {
 	void reportsAFailingCommandAsFailedWithItsExitCode() throws Exception {
 		Path directory = Files.createTempDirectory("mcp-command-fail");
 
+		// the args form, which runs without a shell, so the shell is named explicitly
+		List<String> failing = WINDOWS ? List.of("cmd.exe", "/c", "echo broken 1>&2& exit /b 3")
+				: List.of("/bin/sh", "-c", "echo broken >&2; exit 3");
 		Map<String, Object> result = TestFixture.callAndParse("eclipse_run_command",
-				Map.of("args", List.of("sh", "-c", "echo broken >&2; exit 3"), "directory",
+				Map.of("args", failing, "directory",
 						directory.toString(), "wait", Boolean.TRUE, "timeoutSeconds", Integer.valueOf(20)));
 
 		assertEquals("failed", result.get("state"), "got " + result);
@@ -53,8 +59,12 @@ class RunCommandToolTest {
 
 	@Test
 	void refusesADirectoryThatDoesNotExist() throws Exception {
+		// absolute on every window system: a bare /no/such/... is relative on Windows,
+		// where it would be refused for the wrong reason
+		String missing = Path.of(System.getProperty("java.io.tmpdir")).toAbsolutePath()
+				.resolve("no-such-directory-here").toString();
 		McpToolResult result = TestFixture.call("eclipse_run_command",
-				Map.of("command", "echo hello", "directory", "/no/such/directory/here"));
+				Map.of("command", "echo hello", "directory", missing));
 
 		assertTrue(result.isError(), "got " + result.text());
 		assertTrue(result.text().contains("no directory"), "got " + result.text());


### PR DESCRIPTION
Everything here has only ever run on Linux, so the platform specific paths were unexercised rather than known good.
The largest fix is a whole class rather than a single site: a `Location`'s URL is not a filesystem path, and both obvious ways of making one are wrong off Linux, so `FileLocations` now owns that conversion and the configuration area, the install location, a `bundles.info` entry, the workspace a restart is sent to and the jars a target platform search reads all go through it.
The rest are separate failures: process output decoded as UTF-8 instead of the Windows console code page, a CRLF file that could not be matched against text given with LF, a drive letter read as a URI scheme, an unquoted flight recording path, a temp directory check compared as strings, project paths matched by a case sensitive prefix, a launched platform's log read as strict UTF-8, and a token file with no owner-only restriction where POSIX permissions do not exist.

Three tests that could only pass on Linux no longer depend on the window system, and the new conversion and the CRLF match have tests of their own.
Nothing here was run on Windows or macOS: these are defects found by reading, so the obvious next step is a CI matrix, which is deliberately not part of this change because it cannot be verified from here.
