### PR TITLE
Detect JUnit Platform major version to pick junit5 vs junit6 launch kind

### DIFF
--- a/plugins/com.vogella.eclipse.mcp.jdt/src/com/vogella/eclipse/mcp/jdt/internal/RunTestsTool.java
+++ b/plugins/com.vogella.eclipse.mcp.jdt/src/com/vogella/eclipse/mcp/jdt/internal/RunTestsTool.java
@@ -685,16 +685,108 @@ public final class RunTestsTool implements IMcpTool {
 	}
 
 	/**
-	 * Which JUnit the project is on, read from its own build path. JDT then supplies
-	 * the matching runner, so nothing here has to know about JUnit itself.
+	 * Selects the JDT runner from the project's JUnit Platform version.
 	 */
 	private static String testKind(IJavaProject javaProject) throws CoreException {
+		// Testable is the platform-commons annotation JDT itself keys the check on,
+		// so resolving it, rather than jupiter-api, matches the delegate exactly and
+		// gives the platform jar whose version decides junit5 versus junit6
+		IType testable = javaProject.findType("org.junit.platform.commons.annotation.Testable"); //$NON-NLS-1$
+		if (testable != null) {
+			return platformMajorVersion(testable) >= 6 ? "org.eclipse.jdt.junit.loader.junit6" //$NON-NLS-1$
+					: "org.eclipse.jdt.junit.loader.junit5"; //$NON-NLS-1$
+		}
 		if (javaProject.findType("org.junit.jupiter.api.Test") != null) { //$NON-NLS-1$
+			// jupiter present but platform-commons unresolved: keep the old behaviour
 			return "org.eclipse.jdt.junit.loader.junit5"; //$NON-NLS-1$
 		}
 		if (javaProject.findType("org.junit.Test") != null) { //$NON-NLS-1$
 			return "org.eclipse.jdt.junit.loader.junit4"; //$NON-NLS-1$
 		}
 		return "org.eclipse.jdt.junit.loader.junit3"; //$NON-NLS-1$
+	}
+
+	/**
+	 * Reads the JUnit Platform major version from the annotation's JAR name or manifest.
+	 */
+	private static int platformMajorVersion(IType testable) {
+		IPackageFragmentRoot root = (IPackageFragmentRoot) testable
+				.getAncestor(org.eclipse.jdt.core.IJavaElement.PACKAGE_FRAGMENT_ROOT);
+		if (root == null) {
+			return 0;
+		}
+		org.eclipse.core.runtime.IPath path = root.getPath();
+		String fileName = path.lastSegment();
+		if (fileName != null && fileName.endsWith(".jar")) { //$NON-NLS-1$
+			String prefix = "junit-platform-commons"; //$NON-NLS-1$
+			// junit-platform-commons-6.0.3.jar and junit-platform-commons_6.0.3.jar
+			if (fileName.startsWith(prefix + "-") || fileName.startsWith(prefix + "_")) { //$NON-NLS-1$ //$NON-NLS-2$
+				int major = majorOf(fileName.substring(prefix.length() + 1, fileName.length() - ".jar".length())); //$NON-NLS-1$
+				if (major > 0) {
+					return major;
+				}
+			}
+		}
+		// version-less name, e.g. a symlink called junit-platform-commons.jar: read
+		// the jar's own manifest, where the real version lives in that case. This
+		// stays on public API, unlike the internal PackageFragmentRoot.getManifest
+		// that CoreTestSearchEngine casts to, by opening the jar file on disk
+		java.io.File jar = toFile(root, path);
+		if (jar != null && jar.isFile()) {
+			try (java.util.jar.JarFile jarFile = new java.util.jar.JarFile(jar)) {
+				Manifest manifest = jarFile.getManifest();
+				if (manifest != null) {
+					// Specification-Version is set by JUnit, Bundle-Version by OSGi; both
+					// carry the same major, so either answers the junit5-or-6 question
+					String version = manifest.getMainAttributes().getValue("Specification-Version"); //$NON-NLS-1$
+					if (version == null) {
+						version = manifest.getMainAttributes().getValue("Bundle-Version"); //$NON-NLS-1$
+					}
+					int major = majorOf(version);
+					if (major > 0) {
+						return major;
+					}
+				}
+			} catch (java.io.IOException | RuntimeException e) {
+				// manifest unreadable: fall through to the junit5 default
+			}
+		}
+		return 0;
+	}
+
+	/**
+	 * Finds the archive behind a package fragment root.
+	 */
+	private static java.io.File toFile(IPackageFragmentRoot root, org.eclipse.core.runtime.IPath path) {
+		IResource resource = root.getResource();
+		if (resource != null && resource.getLocation() != null) {
+			return resource.getLocation().toFile();
+		}
+		// external jar: the path is already an absolute filesystem location
+		if (path != null && path.toFile().isFile()) {
+			return path.toFile();
+		}
+		return null;
+	}
+
+	/**
+	 * Reads the leading numeric segment, or zero when absent.
+	 */
+	private static int majorOf(String version) {
+		if (version == null || version.isEmpty()) {
+			return 0;
+		}
+		int end = 0;
+		while (end < version.length() && Character.isDigit(version.charAt(end))) {
+			end++;
+		}
+		if (end == 0) {
+			return 0;
+		}
+		try {
+			return Integer.parseInt(version.substring(0, end));
+		} catch (NumberFormatException e) {
+			return 0;
+		}
 	}
 }

--- a/tests/com.vogella.eclipse.mcp.core.tests/src/com/vogella/eclipse/mcp/core/tests/RunTestsToolTest.java
+++ b/tests/com.vogella.eclipse.mcp.core.tests/src/com/vogella/eclipse/mcp/core/tests/RunTestsToolTest.java
@@ -4,14 +4,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+
+import javax.tools.ToolProvider;
 
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.vogella.eclipse.mcp.core.McpToolResult;
 
@@ -22,6 +32,9 @@ class RunTestsToolTest {
 	private static final String PROJECT = "mcp-runtests-test";
 
 	private final TestFixture fixture = new TestFixture();
+
+	@TempDir
+	Path temporary;
 
 	@AfterEach
 	void deleteTestProjects() throws Exception {
@@ -72,6 +85,42 @@ class RunTestsToolTest {
 		@SuppressWarnings("unchecked")
 		List<String> types = (List<String>) result.get("testTypes");
 		assertTrue(types.contains("sample.SampleTest"), types.toString());
+	}
+
+	@Test
+	void aDryRunSelectsTheJUnit6RunnerForJUnit6() throws Exception {
+		IJavaProject project = withTests();
+		IClasspathEntry[] existing = project.getRawClasspath();
+		IClasspathEntry[] withPlatform6 = new IClasspathEntry[existing.length + 1];
+		withPlatform6[0] = JavaCore.newLibraryEntry(platformCommons6(), null, null);
+		System.arraycopy(existing, 0, withPlatform6, 1, existing.length);
+		project.setRawClasspath(withPlatform6, null);
+
+		Map<String, Object> result = TestFixture.callAndParse(TOOL,
+				Map.of("project", PROJECT, "dryRun", Boolean.TRUE));
+
+		assertEquals("org.eclipse.jdt.junit.loader.junit6", result.get("testKind"),
+				"JUnit 6 must use JDT's JUnit 6 runner rather than the incompatible JUnit 5 runner");
+	}
+
+	/** Builds a versionless Platform Commons JAR to exercise the manifest fallback. */
+	private org.eclipse.core.runtime.IPath platformCommons6() throws Exception {
+		Path source = temporary.resolve("src/org/junit/platform/commons/annotation/Testable.java"); //$NON-NLS-1$
+		Files.createDirectories(source.getParent());
+		Files.writeString(source, "package org.junit.platform.commons.annotation; public @interface Testable {}\n"); //$NON-NLS-1$
+		Path classes = temporary.resolve("classes"); //$NON-NLS-1$
+		assertEquals(0, ToolProvider.getSystemJavaCompiler().run(null, null, null, "-d", classes.toString(), //$NON-NLS-1$ //$NON-NLS-2$
+				source.toString()));
+		Manifest manifest = new Manifest();
+		manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0"); //$NON-NLS-1$
+		manifest.getMainAttributes().putValue("Specification-Version", "6.0.0"); //$NON-NLS-1$ //$NON-NLS-2$
+		Path jar = temporary.resolve("junit-platform-commons.jar"); //$NON-NLS-1$
+		try (OutputStream output = Files.newOutputStream(jar); JarOutputStream archive = new JarOutputStream(output, manifest)) {
+			archive.putNextEntry(new JarEntry("org/junit/platform/commons/annotation/Testable.class")); //$NON-NLS-1$
+			Files.copy(classes.resolve("org/junit/platform/commons/annotation/Testable.class"), archive); //$NON-NLS-1$
+			archive.closeEntry();
+		}
+		return new org.eclipse.core.runtime.Path(jar.toString());
 	}
 
 	@Test


### PR DESCRIPTION
JDT 3.14 split the JUnit 5 launch kind into junit5 and junit6, and JUnitLaunchConfigurationDelegate.preLaunchCheck rejects a junit5 launch whose JUnit Platform is major 6 with a missing-Testable error. testKind now resolves org.junit.platform.commons.annotation.Testable and reads the platform major version off its jar (from the file name, falling back to the jar's own manifest), the same way TestKindRegistry does, and only falls back to the old jupiter-present check when Testable cannot be resolved at all.